### PR TITLE
Add names to VPC resources in existing-resources example

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -11,7 +11,7 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/nebari-dev/projects/12
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/examples/existing-resources/vpc.tf
+++ b/examples/existing-resources/vpc.tf
@@ -7,10 +7,18 @@ resource "aws_vpc" "main" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
   enable_dns_support   = true
+
+  tags = {
+    Name = var.project_name
+  }
 }
 
 resource "aws_internet_gateway" "main" {
   vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = var.project_name
+  }
 }
 
 # Create three (one per AZ) public subnets (for NAT Gateways)
@@ -21,7 +29,10 @@ resource "aws_subnet" "public" {
   availability_zone       = data.aws_availability_zones.available.names[count.index]
   map_public_ip_on_launch = true
 
-  tags = { "kubernetes.io/role/elb" = "1" }
+  tags = {
+    Name                     = "${var.project_name}-public-${data.aws_availability_zones.available.names[count.index]}"
+    "kubernetes.io/role/elb" = "1"
+  }
 }
 
 # Create three private subnets (for EKS nodes)
@@ -31,12 +42,19 @@ resource "aws_subnet" "private" {
   cidr_block        = cidrsubnet(aws_vpc.main.cidr_block, 8, count.index + 10)
   availability_zone = data.aws_availability_zones.available.names[count.index]
 
-  tags = { "kubernetes.io/role/internal-elb" = "1" }
+  tags = {
+    Name                              = "${var.project_name}-private-${data.aws_availability_zones.available.names[count.index]}"
+    "kubernetes.io/role/internal-elb" = "1"
+  }
 }
 
 # Create Elastic IP for NAT Gateway
 resource "aws_eip" "nat" {
   domain = "vpc"
+
+  tags = {
+    Name = "${var.project_name}-${data.aws_availability_zones.available.names[0]}"
+  }
 
   depends_on = [aws_internet_gateway.main]
 }
@@ -45,6 +63,10 @@ resource "aws_eip" "nat" {
 resource "aws_nat_gateway" "main" {
   allocation_id = aws_eip.nat.id
   subnet_id     = aws_subnet.public[0].id
+
+  tags = {
+    Name = "${var.project_name}-${data.aws_availability_zones.available.names[0]}"
+  }
 
   depends_on = [aws_internet_gateway.main]
 }
@@ -56,6 +78,10 @@ resource "aws_route_table" "public" {
   route {
     cidr_block = "0.0.0.0/0"
     gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.project_name}-public"
   }
 }
 
@@ -73,6 +99,10 @@ resource "aws_route_table" "private" {
   route {
     cidr_block     = "0.0.0.0/0"
     nat_gateway_id = aws_nat_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.project_name}-private"
   }
 }
 


### PR DESCRIPTION
## Reference Issues or PRs

## What does this implement/fix?

This PR adds names to the VPC resources independently created (as in they're not part of the module) in the `existing-resources` example. This make it easier for people deploying the example to identify the VPC resources that were deployed as part of it.

## Testing