### PR TITLE
Add node_security_group_additional_rules pass-through

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -63,6 +63,28 @@ content: |-
     efs_throughput_mode  = "elastic"
     efs_encrypted        = true
 
+    # Node security group rules
+    # Open ports for Longhorn admission (9502) and conversion (9501) webhooks
+    # so the EKS control plane can reach them on the nodes.
+    node_security_group_additional_rules = {
+      longhorn_webhook_admission = {
+        description                   = "Cluster API to Longhorn admission webhook"
+        protocol                      = "tcp"
+        from_port                     = 9502
+        to_port                       = 9502
+        type                          = "ingress"
+        source_cluster_security_group = true
+      }
+      longhorn_webhook_conversion = {
+        description                   = "Cluster API to Longhorn conversion webhook"
+        protocol                      = "tcp"
+        from_port                     = 9501
+        to_port                       = 9501
+        type                          = "ingress"
+        source_cluster_security_group = true
+      }
+    }
+
     tags = {
       Example = "eks-cluster"
       Project = "terraform-aws-eks-cluster"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ module "cluster" {
   efs_throughput_mode  = "elastic"
   efs_encrypted        = true
 
+  # Node security group rules
+  # Open ports for Longhorn admission (9502) and conversion (9501) webhooks
+  # so the EKS control plane can reach them on the nodes.
+  node_security_group_additional_rules = {
+    longhorn_webhook_admission = {
+      description                   = "Cluster API to Longhorn admission webhook"
+      protocol                      = "tcp"
+      from_port                     = 9502
+      to_port                       = 9502
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
+    longhorn_webhook_conversion = {
+      description                   = "Cluster API to Longhorn conversion webhook"
+      protocol                      = "tcp"
+      from_port                     = 9501
+      to_port                       = 9501
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
+  }
+
   tags = {
     Example = "eks-cluster"
     Project = "terraform-aws-eks-cluster"
@@ -120,6 +142,7 @@ module "cluster" {
 | <a name="input_iam_role_permissions_boundary"></a> [iam\_role\_permissions\_boundary](#input\_iam\_role\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for IAM roles created by this module. | `string` | `null` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes `<major>.<minor>` version to use for the EKS cluster (i.e.: `1.33`) | `string` | `null` | no |
 | <a name="input_node_groups"></a> [node\_groups](#input\_node\_groups) | Map of node groups to create. Each node group supports the following attributes:<br/>- instance (required): EC2 instance type (e.g., "m5.xlarge")<br/>- min\_nodes: Minimum number of nodes (default: 0)<br/>- max\_nodes: Maximum number of nodes (default: 1)<br/>- ami\_type: Override AMI type (AL2023\_x86\_64\_STANDARD, AL2023\_ARM\_64\_STANDARD, AL2023\_x86\_64\_NVIDIA, etc.)<br/>- spot: Use Spot instances for cost savings (default: false)<br/>- disk\_size: Root disk size in GB (default: 20)<br/>- labels: Map of Kubernetes labels to apply to nodes (default: {})<br/>- taints: List of Kubernetes taints with keys: key, value, effect | <pre>map(object({<br/>    instance  = string<br/>    min_nodes = optional(number, 0)<br/>    max_nodes = optional(number, 1)<br/>    ami_type  = optional(string, "AL2023_x86_64_STANDARD")<br/>    spot      = optional(bool, false)<br/>    disk_size = optional(number, null)<br/>    labels    = optional(map(string), {})<br/>    taints = optional(list(object({<br/>      key    = string<br/>      value  = string<br/>      effect = string # NO_SCHEDULE, NO_EXECUTE, or PREFER_NO_SCHEDULE<br/>    })), [])<br/>  }))</pre> | n/a | yes |
+| <a name="input_node_security_group_additional_rules"></a> [node\_security\_group\_additional\_rules](#input\_node\_security\_group\_additional\_rules) | Additional security group rules to add to the node security group created by the EKS module. Set source\_cluster\_security\_group = true to allow traffic from the cluster security group. | `any` | `{}` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | The name of the project. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_vpc_cidr_block"></a> [vpc\_cidr\_block](#input\_vpc\_cidr\_block) | The CIDR block for the VPC. | `string` | `"10.0.0.0/16"` | no |
@@ -142,6 +165,7 @@ module "cluster" {
 | <a name="output_kubeconfig_command"></a> [kubeconfig\_command](#output\_kubeconfig\_command) | Command to update kubeconfig |
 | <a name="output_node_groups"></a> [node\_groups](#output\_node\_groups) | Outputs from EKS node groups |
 | <a name="output_node_iam_role_arn"></a> [node\_iam\_role\_arn](#output\_node\_iam\_role\_arn) | IAM role ARN used by EKS node groups |
+| <a name="output_node_security_group_id"></a> [node\_security\_group\_id](#output\_node\_security\_group\_id) | ID of the node shared security group |
 | <a name="output_oidc_provider_arn"></a> [oidc\_provider\_arn](#output\_oidc\_provider\_arn) | ARN of the OIDC Provider for EKS (for IRSA) |
 | <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | List of IDs of private subnets used by the EKS cluster |
 | <a name="output_public_subnet_ids"></a> [public\_subnet\_ids](#output\_public\_subnet\_ids) | List of IDs of created public subnets (empty list if using existing subnets) |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -43,6 +43,26 @@ module "cluster" {
   efs_throughput_mode  = "elastic"
   efs_encrypted        = true
 
+  # Node security group rules
+  node_security_group_additional_rules = {
+    longhorn_webhook_admission = {
+      description                   = "Cluster API to Longhorn admission webhook"
+      protocol                      = "tcp"
+      from_port                     = 9502
+      to_port                       = 9502
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
+    longhorn_webhook_conversion = {
+      description                   = "Cluster API to Longhorn conversion webhook"
+      protocol                      = "tcp"
+      from_port                     = 9501
+      to_port                       = 9501
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
+  }
+
   tags = {
     Example = "cluster"
     Project = "terraform-aws-eks-cluster"

--- a/main.tf
+++ b/main.tf
@@ -103,6 +103,8 @@ module "eks" {
 
   enabled_log_types = var.cluster_enabled_log_types
 
+  node_security_group_additional_rules = var.node_security_group_additional_rules
+
   eks_managed_node_groups = local.node_groups
 
   tags = var.tags

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,6 +47,11 @@ output "node_groups" {
   value       = module.eks.eks_managed_node_groups
 }
 
+output "node_security_group_id" {
+  description = "ID of the node shared security group"
+  value       = module.eks.node_security_group_id
+}
+
 ################################################################################
 # Networking
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -208,9 +208,6 @@ variable "node_groups" {
   }
 }
 
-################################################################################
-# Node Security Group
-################################################################################
 variable "node_security_group_additional_rules" {
   description = "Additional security group rules to add to the node security group created by the EKS module. Set source_cluster_security_group = true to allow traffic from the cluster security group."
   type        = any

--- a/variables.tf
+++ b/variables.tf
@@ -209,6 +209,15 @@ variable "node_groups" {
 }
 
 ################################################################################
+# Node Security Group
+################################################################################
+variable "node_security_group_additional_rules" {
+  description = "Additional security group rules to add to the node security group created by the EKS module. Set source_cluster_security_group = true to allow traffic from the cluster security group."
+  type        = any
+  default     = {}
+}
+
+################################################################################
 # EFS
 ################################################################################
 variable "efs_enabled" {


### PR DESCRIPTION
## Summary

- Exposes the upstream `node_security_group_additional_rules` variable from `terraform-aws-modules/eks/aws` so callers can add custom ingress rules to the node shared security group
- Adds `node_security_group_id` output for visibility into the node security group

## Context

The EKS module's node shared security group only allows control-plane-to-node traffic on well-known webhook ports (443, 4443, 6443, 8443, 9443, 10250, 10251). Services like Longhorn use non-standard ports (9501-9502) for admission and conversion webhooks, causing the kube-apiserver webhook calls to time out with "context deadline exceeded".

This pass-through variable lets callers open additional ports as needed.

## Test plan

- [ ] Verify `tofu validate` passes
- [ ] Deploy cluster with custom SG rules and confirm they appear on the node security group
- [ ] Verify Longhorn admission webhook is reachable on port 9502 from the control plane