### PR TITLE
Refactor VPC resource tags to use project name variable in existing-resources example

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,7 +1,7 @@
 module "cluster" {
   source = "../.."
 
-  project_name = "ex-complete"
+  project_name = var.project_name
 
   # VPC configuration
   create_vpc         = true

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,0 +1,4 @@
+variable "project_name" {
+  type        = string
+  default     = "ex-complete"
+}

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,4 +1,4 @@
 variable "project_name" {
-  type        = string
-  default     = "ex-complete"
+  type    = string
+  default = "ex-complete"
 }

--- a/examples/existing-resources/main.tf
+++ b/examples/existing-resources/main.tf
@@ -1,7 +1,7 @@
 module "cluster" {
   source = "../.."
 
-  project_name = "ex-existing-resources"
+  project_name = var.project_name
 
   # Use existing VPC and subnets
   create_vpc                  = false

--- a/examples/existing-resources/variables.tf
+++ b/examples/existing-resources/variables.tf
@@ -1,4 +1,4 @@
 variable "project_name" {
-  type        = string
-  default     = "ex-existing-resources"
+  type    = string
+  default = "ex-existing-resources"
 }

--- a/examples/existing-resources/variables.tf
+++ b/examples/existing-resources/variables.tf
@@ -1,0 +1,4 @@
+variable "project_name" {
+  type        = string
+  default     = "ex-existing-resources"
+}

--- a/examples/existing-resources/vpc.tf
+++ b/examples/existing-resources/vpc.tf
@@ -1,3 +1,7 @@
+locals {
+  project_name = "ex-existing-resources"
+}
+
 data "aws_availability_zones" "available" {
   state = "available"
 }
@@ -9,7 +13,7 @@ resource "aws_vpc" "main" {
   enable_dns_support   = true
 
   tags = {
-    Name = var.project_name
+    Name = local.project_name
   }
 }
 
@@ -17,7 +21,7 @@ resource "aws_internet_gateway" "main" {
   vpc_id = aws_vpc.main.id
 
   tags = {
-    Name = var.project_name
+    Name = local.project_name
   }
 }
 
@@ -30,7 +34,7 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch = true
 
   tags = {
-    Name                     = "${var.project_name}-public-${data.aws_availability_zones.available.names[count.index]}"
+    Name                     = "${local.project_name}-public-${data.aws_availability_zones.available.names[count.index]}"
     "kubernetes.io/role/elb" = "1"
   }
 }
@@ -43,7 +47,7 @@ resource "aws_subnet" "private" {
   availability_zone = data.aws_availability_zones.available.names[count.index]
 
   tags = {
-    Name                              = "${var.project_name}-private-${data.aws_availability_zones.available.names[count.index]}"
+    Name                              = "${local.project_name}-private-${data.aws_availability_zones.available.names[count.index]}"
     "kubernetes.io/role/internal-elb" = "1"
   }
 }
@@ -53,7 +57,7 @@ resource "aws_eip" "nat" {
   domain = "vpc"
 
   tags = {
-    Name = "${var.project_name}-${data.aws_availability_zones.available.names[0]}"
+    Name = "${local.project_name}-${data.aws_availability_zones.available.names[0]}"
   }
 
   depends_on = [aws_internet_gateway.main]
@@ -65,7 +69,7 @@ resource "aws_nat_gateway" "main" {
   subnet_id     = aws_subnet.public[0].id
 
   tags = {
-    Name = "${var.project_name}-${data.aws_availability_zones.available.names[0]}"
+    Name = "${local.project_name}-${data.aws_availability_zones.available.names[0]}"
   }
 
   depends_on = [aws_internet_gateway.main]
@@ -81,7 +85,7 @@ resource "aws_route_table" "public" {
   }
 
   tags = {
-    Name = "${var.project_name}-public"
+    Name = "${local.project_name}-public"
   }
 }
 
@@ -102,7 +106,7 @@ resource "aws_route_table" "private" {
   }
 
   tags = {
-    Name = "${var.project_name}-private"
+    Name = "${local.project_name}-private"
   }
 }
 

--- a/examples/existing-resources/vpc.tf
+++ b/examples/existing-resources/vpc.tf
@@ -1,7 +1,3 @@
-locals {
-  project_name = "ex-existing-resources"
-}
-
 data "aws_availability_zones" "available" {
   state = "available"
 }
@@ -13,7 +9,7 @@ resource "aws_vpc" "main" {
   enable_dns_support   = true
 
   tags = {
-    Name = local.project_name
+    Name = var.project_name
   }
 }
 
@@ -21,7 +17,7 @@ resource "aws_internet_gateway" "main" {
   vpc_id = aws_vpc.main.id
 
   tags = {
-    Name = local.project_name
+    Name = var.project_name
   }
 }
 
@@ -34,7 +30,7 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch = true
 
   tags = {
-    Name                     = "${local.project_name}-public-${data.aws_availability_zones.available.names[count.index]}"
+    Name                     = "${var.project_name}-public-${data.aws_availability_zones.available.names[count.index]}"
     "kubernetes.io/role/elb" = "1"
   }
 }
@@ -47,7 +43,7 @@ resource "aws_subnet" "private" {
   availability_zone = data.aws_availability_zones.available.names[count.index]
 
   tags = {
-    Name                              = "${local.project_name}-private-${data.aws_availability_zones.available.names[count.index]}"
+    Name                              = "${var.project_name}-private-${data.aws_availability_zones.available.names[count.index]}"
     "kubernetes.io/role/internal-elb" = "1"
   }
 }
@@ -57,7 +53,7 @@ resource "aws_eip" "nat" {
   domain = "vpc"
 
   tags = {
-    Name = "${local.project_name}-${data.aws_availability_zones.available.names[0]}"
+    Name = "${var.project_name}-${data.aws_availability_zones.available.names[0]}"
   }
 
   depends_on = [aws_internet_gateway.main]
@@ -69,7 +65,7 @@ resource "aws_nat_gateway" "main" {
   subnet_id     = aws_subnet.public[0].id
 
   tags = {
-    Name = "${local.project_name}-${data.aws_availability_zones.available.names[0]}"
+    Name = "${var.project_name}-${data.aws_availability_zones.available.names[0]}"
   }
 
   depends_on = [aws_internet_gateway.main]
@@ -85,7 +81,7 @@ resource "aws_route_table" "public" {
   }
 
   tags = {
-    Name = "${local.project_name}-public"
+    Name = "${var.project_name}-public"
   }
 }
 
@@ -106,7 +102,7 @@ resource "aws_route_table" "private" {
   }
 
   tags = {
-    Name = "${local.project_name}-private"
+    Name = "${var.project_name}-private"
   }
 }
 

--- a/test/module_test.go
+++ b/test/module_test.go
@@ -24,14 +24,12 @@ const (
 // and registers a cleanup to remove it when the test ends. The override file uses
 // Terraform's override mechanism to change values that are intentionally hardcoded
 // in the examples and that are needed for the tests to run.
-func writeTestOverride(t *testing.T, exampleDir, projectName string) {
+func writeTestOverride(t *testing.T, exampleDir string) {
 	t.Helper()
 
 	overrides := map[string]any{
 		"module": map[string]any{
 			"cluster": map[string]any{
-				// Use a unique project name to avoid name collision in the same AWS account
-				"project_name": projectName,
 				// The endpoint public access and the admin permissions are enabled so
 				// the tests can run k8s commands against the cluster, regardless of the
 				// values set in the examples.
@@ -105,12 +103,14 @@ func TestExampleComplete(t *testing.T) {
 	t.Parallel()
 
 	exampleFolder := "../examples/complete"
-	randomProjectName := "test-complete-" + random.UniqueId()
-	writeTestOverride(t, exampleFolder, randomProjectName)
+	writeTestOverride(t, exampleFolder)
 
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir:    exampleFolder,
 		TerraformBinary: "tofu",
+		Vars: map[string]any{
+			"project_name": "test-complete-" + random.UniqueId(),
+		},
 	})
 
 	// Make sure to destroy resources at the end of the test, regardless of whether the test passes or fails
@@ -130,12 +130,14 @@ func TestExampleExistingResources(t *testing.T) {
 	t.Parallel()
 
 	exampleFolder := "../examples/existing-resources"
-	randomProjectName := "test-existing-" + random.UniqueId()
-	writeTestOverride(t, exampleFolder, randomProjectName)
+	writeTestOverride(t, exampleFolder)
 
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir:    exampleFolder,
 		TerraformBinary: "tofu",
+		Vars: map[string]any{
+			"project_name": "test-existing-" + random.UniqueId(),
+		},
 	})
 
 	// Make sure to destroy resources at the end of the test, regardless of whether the test passes or fails


### PR DESCRIPTION
## What does this implement/fix?

#14 changed the way the integration tests call the examples, avoiding the need to specify `project_name` as a variable and using overrides instead. This made the example simpler without requiring variables. However, #15 relied on the `project_name` variable to add a name to the VPC resources created outside of the module.

This PR reintroduces the `project_name` variable and updates the test to reflect that. This is preferred over hardcoding the name for the vpc resources or having a local variable, because our integration tests rely on having project names with a random suffix to avoid collisions and adding an override file for the vpc resources is far from ideal.