### PR TITLE
Update IAM role names in existing-resources example to avoid potential name collisions in integration tests

### DIFF
--- a/examples/existing-resources/iam.tf
+++ b/examples/existing-resources/iam.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role" "cluster" {
-  name        = "example-cluster-role"
-  description = "EKS cluster role for cluster-only example"
+  name        = "${var.project_name}-cluster-role"
+  description = "EKS cluster role for the ${var.project_name} project"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -25,8 +25,8 @@ resource "aws_iam_role_policy_attachment" "cluster_amazon_eks_vpc_resource_contr
 }
 
 resource "aws_iam_role" "node" {
-  name        = "example-node-role"
-  description = "EKS node role for cluster-only example"
+  name        = "${var.project_name}-node-role"
+  description = "EKS node role for the ${var.project_name} project"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"


### PR DESCRIPTION
## What does this implement/fix?

The IAM roles created outside of the module in the existing-resources example use a hardcoded name. While this is fine for an example, we rely on those examples to run our integration tests and there can be potential name collisions between tests that failed to properly clean up resources and those that are trying to deploy from scratch. An example can be found here: https://github.com/nebari-dev/terraform-aws-eks-cluster/actions/runs/22357389780/job/64700777473