### PR TITLE
Add EFS CSI driver addon and IAM when EFS is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ module "cluster" {
 
 | Name | Type |
 |------|------|
+| [aws_security_group_rule.efs_nfs_from_nodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ module "cluster" {
 |------|--------|---------|
 | <a name="module_ebs_csi_pod_identity"></a> [ebs\_csi\_pod\_identity](#module\_ebs\_csi\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.7.0 |
 | <a name="module_efs"></a> [efs](#module\_efs) | terraform-aws-modules/efs/aws | 2.0.0 |
+| <a name="module_efs_csi_pod_identity"></a> [efs\_csi\_pod\_identity](#module\_efs\_csi\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.7.0 |
 | <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 21.11.0 |
 | <a name="module_iam"></a> [iam](#module\_iam) | ./modules/iam | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 6.5.1 |
@@ -160,6 +161,7 @@ module "cluster" {
 | <a name="output_cluster_oidc_issuer_url"></a> [cluster\_oidc\_issuer\_url](#output\_cluster\_oidc\_issuer\_url) | The URL on the EKS cluster for the OpenID Connect identity provider |
 | <a name="output_cluster_security_group_id"></a> [cluster\_security\_group\_id](#output\_cluster\_security\_group\_id) | Security group ID attached to the EKS cluster |
 | <a name="output_efs_arn"></a> [efs\_arn](#output\_efs\_arn) | The ARN of the EFS file system (null if EFS not enabled) |
+| <a name="output_efs_csi_driver_role_arn"></a> [efs\_csi\_driver\_role\_arn](#output\_efs\_csi\_driver\_role\_arn) | IAM role ARN for the EFS CSI driver (null if EFS not enabled) |
 | <a name="output_efs_dns_name"></a> [efs\_dns\_name](#output\_efs\_dns\_name) | The DNS name of the EFS file system (null if EFS not enabled) |
 | <a name="output_efs_id"></a> [efs\_id](#output\_efs\_id) | The ID of the EFS file system (null if EFS not enabled) |
 | <a name="output_kubeconfig_command"></a> [kubeconfig\_command](#output\_kubeconfig\_command) | Command to update kubeconfig |

--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ module "cluster" {
 
 | Name | Type |
 |------|------|
-| [aws_security_group_rule.efs_nfs_from_nodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -89,6 +89,11 @@ output "efs_dns_name" {
   value       = module.cluster.efs_dns_name
 }
 
+output "efs_csi_driver_role_arn" {
+  description = "IAM role ARN for the EFS CSI driver (null if EFS not enabled)"
+  value       = module.cluster.efs_csi_driver_role_arn
+}
+
 output "kubeconfig_command" {
   description = "Command to update kubeconfig"
   value       = module.cluster.kubeconfig_command

--- a/locals.tf
+++ b/locals.tf
@@ -89,6 +89,14 @@ locals {
 
       vpc_security_group_ids = local.additional_node_security_group_ids
 
+      # Attach the EKS-managed primary cluster SG to nodes when we own the SG
+      # setup. This SG allows all traffic between its members, which lets EFS
+      # mount targets (attached to the primary SG) accept NFS from nodes
+      # without a standalone rule, and future-proofs any addon that needs
+      # node-to-cluster-SG communication. When create_security_group is false,
+      # users bring their own SG and manage their own rules.
+      attach_cluster_primary_security_group = var.create_security_group
+
       labels = config.labels
 
       # The EKS module expects taints as a map

--- a/locals.tf
+++ b/locals.tf
@@ -59,8 +59,21 @@ locals {
 
       instance_types = [config.instance]
       capacity_type  = config.spot ? "SPOT" : "ON_DEMAND"
-      disk_size      = config.disk_size
       ami_type       = config.ami_type
+
+      # disk_size must be set via block_device_mappings because the upstream EKS
+      # module creates a custom launch template by default, which causes the
+      # node group disk_size field to be ignored by the EKS API.
+      block_device_mappings = config.disk_size != null ? {
+        root = {
+          device_name = "/dev/xvda"
+          ebs = {
+            volume_size           = config.disk_size
+            volume_type           = "gp3"
+            delete_on_termination = true
+          }
+        }
+      } : {}
 
       min_size     = config.min_nodes
       max_size     = config.max_nodes

--- a/locals.tf
+++ b/locals.tf
@@ -24,17 +24,20 @@ locals {
   # with the VPC if existing ones are not provided.
   private_subnet_ids = var.create_vpc ? flatten(module.vpc[*].private_subnets) : var.existing_private_subnet_ids
 
-  interface_vpc_endpoint_services = var.create_vpc ? [
-    "ec2",
-    "ecr.api",
-    "ecr.dkr",
-    "sts",
-    "eks",
-    "eks-auth",
-    "logs",
-    "elasticloadbalancing",
-    "autoscaling",
-  ] : []
+  interface_vpc_endpoint_services = var.create_vpc ? concat(
+    [
+      "ec2",
+      "ecr.api",
+      "ecr.dkr",
+      "sts",
+      "eks",
+      "eks-auth",
+      "logs",
+      "elasticloadbalancing",
+      "autoscaling",
+    ],
+    var.efs_enabled ? ["elasticfilesystem"] : [],
+  ) : []
   gateway_vpc_endpoint_services = var.create_vpc ? [
     "s3",
   ] : []

--- a/main.tf
+++ b/main.tf
@@ -150,22 +150,6 @@ module "vpc_endpoints" {
   tags = var.tags
 }
 
-# Allow NFS traffic from nodes to EFS mount targets. Mount targets use the
-# cluster security group, but nodes use a separate node security group, so
-# without this rule NFS (TCP 2049) is blocked and PVC mounts time out.
-# See: https://github.com/nebari-dev/terraform-aws-eks-cluster/issues/22
-resource "aws_security_group_rule" "efs_nfs_from_nodes" {
-  count = var.efs_enabled ? 1 : 0
-
-  type                     = "ingress"
-  from_port                = 2049
-  to_port                  = 2049
-  protocol                 = "tcp"
-  security_group_id        = local.cluster_security_group_id
-  source_security_group_id = module.eks.node_security_group_id
-  description              = "NFS from EKS nodes to EFS mount targets"
-}
-
 module "efs" {
   source  = "terraform-aws-modules/efs/aws"
   version = "2.0.0"

--- a/main.tf
+++ b/main.tf
@@ -150,6 +150,22 @@ module "vpc_endpoints" {
   tags = var.tags
 }
 
+# Allow NFS traffic from nodes to EFS mount targets. Mount targets use the
+# cluster security group, but nodes use a separate node security group, so
+# without this rule NFS (TCP 2049) is blocked and PVC mounts time out.
+# See: https://github.com/nebari-dev/terraform-aws-eks-cluster/issues/22
+resource "aws_security_group_rule" "efs_nfs_from_nodes" {
+  count = var.efs_enabled ? 1 : 0
+
+  type                     = "ingress"
+  from_port                = 2049
+  to_port                  = 2049
+  protocol                 = "tcp"
+  security_group_id        = local.cluster_security_group_id
+  source_security_group_id = module.eks.node_security_group_id
+  description              = "NFS from EKS nodes to EFS mount targets"
+}
+
 module "efs" {
   source  = "terraform-aws-modules/efs/aws"
   version = "2.0.0"

--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,19 @@ module "ebs_csi_pod_identity" {
   tags = var.tags
 }
 
+module "efs_csi_pod_identity" {
+  source  = "terraform-aws-modules/eks-pod-identity/aws"
+  version = "2.7.0"
+
+  count = var.efs_enabled ? 1 : 0
+
+  name = "${var.project_name}-aws-efs-csi"
+
+  attach_aws_efs_csi_policy = true
+
+  tags = var.tags
+}
+
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "21.11.0"
@@ -58,22 +71,32 @@ module "eks" {
   name               = var.project_name
   kubernetes_version = var.kubernetes_version
 
-  addons = {
-    aws-ebs-csi-driver = {
-      pod_identity_association = [{
-        role_arn        = module.ebs_csi_pod_identity.iam_role_arn,
-        service_account = "ebs-csi-controller-sa"
-      }]
-    }
-    coredns = {}
-    eks-pod-identity-agent = {
-      before_compute = true
-    }
-    kube-proxy = {}
-    vpc-cni = {
-      before_compute = true
-    }
-  }
+  addons = merge(
+    {
+      aws-ebs-csi-driver = {
+        pod_identity_association = [{
+          role_arn        = module.ebs_csi_pod_identity.iam_role_arn,
+          service_account = "ebs-csi-controller-sa"
+        }]
+      }
+      coredns = {}
+      eks-pod-identity-agent = {
+        before_compute = true
+      }
+      kube-proxy = {}
+      vpc-cni = {
+        before_compute = true
+      }
+    },
+    var.efs_enabled ? {
+      aws-efs-csi-driver = {
+        pod_identity_association = [{
+          role_arn        = one(module.efs_csi_pod_identity[*].iam_role_arn)
+          service_account = "efs-csi-controller-sa"
+        }]
+      }
+    } : {}
+  )
 
   # Use existing security group if provided or have EKS create one otherwise
   create_security_group = var.create_security_group

--- a/outputs.tf
+++ b/outputs.tf
@@ -103,6 +103,11 @@ output "efs_dns_name" {
   value       = one(module.efs[*].dns_name)
 }
 
+output "efs_csi_driver_role_arn" {
+  description = "IAM role ARN for the EFS CSI driver (null if EFS not enabled)"
+  value       = one(module.efs_csi_pod_identity[*].iam_role_arn)
+}
+
 ################################################################################
 # Misc
 ################################################################################


### PR DESCRIPTION
## Summary

- Adds `efs_csi_pod_identity` module (conditional on `efs_enabled`) to create an IAM role with the EFS CSI policy
- Installs `aws-efs-csi-driver` as an EKS addon with pod identity association when EFS is enabled
- Exports `efs_csi_driver_role_arn` output from both the root module and the complete example

## Context

When `efs_enabled = true`, the module creates the EFS filesystem and mount targets but did not install the CSI driver needed for Kubernetes to dynamically provision EFS-backed PVCs. This follows the existing EBS CSI driver pattern exactly.

Closes #20

## Test plan

- [ ] `terraform fmt -recursive` passes (verified)
- [ ] `terraform validate` passes (requires `tofu init`)
- [ ] Deploy with `efs_enabled = true` and verify the `aws-efs-csi-driver` addon appears in the cluster
- [ ] Deploy with `efs_enabled = false` and verify no EFS CSI resources are created
- [ ] Create an EFS-backed StorageClass and verify PVC provisioning works