### PR TITLE
fix: strip duplicate kubernetes.io/cluster tag from shared node SG

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -128,6 +128,20 @@ module "eks" {
 
   node_security_group_additional_rules = var.node_security_group_additional_rules
 
+  # Suppress the upstream module's `kubernetes.io/cluster/<name> = owned` tag on
+  # the shared node SG. EKS auto-adds the same tag to its mandatory cluster
+  # primary SG (which gets attached to every managed-node-group node), so two
+  # SGs end up tagged. The AWS Load Balancer Controller refuses that ambiguity
+  # ("expected exactly one securityGroup tagged with kubernetes.io/cluster/...")
+  # and silently fails to add ingress rules to the node SG, leaving NLB
+  # targets unhealthy. We strip the duplicate tag here rather than disabling
+  # the node SG entirely so node_security_group_additional_rules (used by
+  # consumers like the Longhorn webhook ports) still has a SG to attach to.
+  # See: https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/faq.md
+  node_security_group_tags = {
+    "kubernetes.io/cluster/${var.project_name}" = null
+  }
+
   eks_managed_node_groups = local.node_groups
 
   tags = var.tags


### PR DESCRIPTION
## Summary

EKS automatically tags its cluster primary security group with
`kubernetes.io/cluster/<name>=owned` and attaches that SG to every
managed-node-group node. The upstream `terraform-aws-modules/eks` module
also tags its shared node SG with the same key, so two SGs end up tagged
on the node ENI. The AWS Load Balancer Controller refuses that
ambiguity:

```
expected exactly one securityGroup tagged with kubernetes.io/cluster/<name>
for eni eni-..., got: [<node-sg> <cluster-primary-sg>]
```

When this happens the controller silently fails to add backend ingress
rules to the node SG. NLB targets stay unhealthy and no traffic flows.
Observed downstream symptoms:

- cert-manager HTTP-01 self-checks time out
- Keycloak unreachable from in-cluster pods
- oauth2-proxy / landing-page init containers stall

## Fix

Suppress the duplicate tag on the upstream module's node SG by setting
it to `null` in `node_security_group_tags`. We strip the tag rather than
disabling the SG entirely (`create_node_security_group = false`) so that
`node_security_group_additional_rules` consumers (e.g. the Longhorn
webhook ingress rules) still have a SG to attach to.

Reference: [terraform-aws-eks FAQ](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/faq.md)

## Reference Issues or PRs

Fixes nebari-dev/terraform-aws-eks-cluster#28

## What does this implement/fix?

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

Verified against a live dev cluster: after applying, the node ENI shows
only the cluster primary SG tagged with `kubernetes.io/cluster/<name>`,
the AWS Load Balancer Controller reconciles the target group ingress
rules successfully, and NLB targets transition to healthy.
