### PR TITLE
refactor(userdata): load CA payloads from template files + sync docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ module "cluster" {
 | <a name="module_efs_csi_pod_identity"></a> [efs\_csi\_pod\_identity](#module\_efs\_csi\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.7.0 |
 | <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 21.11.0 |
 | <a name="module_iam"></a> [iam](#module\_iam) | ./modules/iam | n/a |
+| <a name="module_node_userdata"></a> [node\_userdata](#module\_node\_userdata) | ./modules/userdata | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 6.5.1 |
 | <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | ./modules/vpc-endpoints | n/a |
 

--- a/modules/userdata/main.tf
+++ b/modules/userdata/main.tf
@@ -10,6 +10,10 @@ variable "ami_type" {
 }
 
 locals {
+  # Binary dispatch: Bottlerocket -> TOML path, everything else -> AL2023 bash
+  # shellscript. If this module ever needs to support Windows AMI types
+  # (WINDOWS_CORE_*, WINDOWS_FULL_*), revisit this check — they would currently
+  # fall through to the AL2023 path and silently break boot.
   is_bottlerocket = startswith(var.ami_type, "BOTTLEROCKET_")
 
   # AL2023 is RHEL-based: drop anchors under /etc/pki/ca-trust/source/anchors and run

--- a/modules/userdata/main.tf
+++ b/modules/userdata/main.tf
@@ -5,7 +5,7 @@ variable "extra_ca_bundle" {
 }
 
 variable "ami_type" {
-  description = "EKS managed node group AMI type. Used to pick AL2023/AL2 shell-script vs Bottlerocket TOML."
+  description = "EKS managed node group AMI type. Used to pick the AL2023 shell-script vs the Bottlerocket TOML."
   type        = string
 }
 
@@ -14,25 +14,20 @@ locals {
 
   # AL2023 is RHEL-based: drop anchors under /etc/pki/ca-trust/source/anchors and run
   # `update-ca-trust extract` so the bundle ends up in /etc/pki/tls/certs/ca-bundle.crt
-  # before nodeadm/kubelet start. The same script works on AL2.
-  al2_pre_nodeadm_script = var.extra_ca_bundle == null ? null : <<-EOT
-    #!/bin/bash
-    set -euo pipefail
-    install -d -m 0755 /etc/pki/ca-trust/source/anchors
-    echo '${var.extra_ca_bundle}' | base64 -d > /etc/pki/ca-trust/source/anchors/org-ca.crt
-    chmod 0644 /etc/pki/ca-trust/source/anchors/org-ca.crt
-    update-ca-trust extract
-  EOT
+  # before nodeadm/kubelet start.
+  al2_pre_nodeadm_script = var.extra_ca_bundle == null ? null : templatefile(
+    "${path.module}/templates/install-extra-ca-bundle.sh.tftpl",
+    { extra_ca_bundle = var.extra_ca_bundle }
+  )
 
-  bottlerocket_settings = var.extra_ca_bundle == null ? null : <<-EOT
-    [settings.pki.org-ca]
-    data = "${var.extra_ca_bundle}"
-    trusted = true
-  EOT
+  bottlerocket_settings = var.extra_ca_bundle == null ? null : templatefile(
+    "${path.module}/templates/bottlerocket-ca.toml.tftpl",
+    { extra_ca_bundle = var.extra_ca_bundle }
+  )
 }
 
 output "cloudinit_pre_nodeadm" {
-  description = "cloud-init pre-nodeadm parts for AL2023/AL2 node groups. Null when no extra CA bundle is requested or when the AMI is Bottlerocket."
+  description = "cloud-init pre-nodeadm parts for AL2023 node groups. Null when no extra CA bundle is requested or when the AMI is Bottlerocket."
   value = (var.extra_ca_bundle == null || local.is_bottlerocket) ? null : [
     {
       content      = local.al2_pre_nodeadm_script

--- a/modules/userdata/main.tf
+++ b/modules/userdata/main.tf
@@ -2,6 +2,16 @@ variable "extra_ca_bundle" {
   description = "Optional base64-encoded PEM bundle to install into the node OS trust store. Unset means no changes."
   type        = string
   default     = null
+
+  # The bundle is interpolated into a single-quoted shell command and a TOML
+  # basic string in the templates below. The base64 alphabet excludes quotes
+  # and backslashes, so a value that decodes cleanly cannot break out of either
+  # context. Enforcing it here keeps that guarantee local to the templating,
+  # rather than relying on the parent module having already validated it.
+  validation {
+    condition     = var.extra_ca_bundle == null || can(base64decode(var.extra_ca_bundle))
+    error_message = "extra_ca_bundle must be a valid base64-encoded string."
+  }
 }
 
 variable "ami_type" {

--- a/modules/userdata/templates/bottlerocket-ca.toml.tftpl
+++ b/modules/userdata/templates/bottlerocket-ca.toml.tftpl
@@ -1,0 +1,3 @@
+[settings.pki.org-ca]
+data = "${extra_ca_bundle}"
+trusted = true

--- a/modules/userdata/templates/install-extra-ca-bundle.sh.tftpl
+++ b/modules/userdata/templates/install-extra-ca-bundle.sh.tftpl
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+install -d -m 0755 /etc/pki/ca-trust/source/anchors
+echo '${extra_ca_bundle}' | base64 -d > /etc/pki/ca-trust/source/anchors/org-ca.crt
+chmod 0644 /etc/pki/ca-trust/source/anchors/org-ca.crt
+update-ca-trust extract

--- a/modules/userdata/userdata.tftest.hcl
+++ b/modules/userdata/userdata.tftest.hcl
@@ -26,6 +26,9 @@ run "al2023_renders_cloudinit_pre_nodeadm" {
     error_message = "Cloud-init part must declare a shellscript MIME content type so cloud-init executes it."
   }
 
+  # Literal base64 (not ${var.extra_ca_bundle}) so the assertion isn't coupled
+  # to the same variable the production code interpolates — if the module ever
+  # transformed the bundle on its way into the template, this would still catch it.
   assert {
     condition     = strcontains(output.cloudinit_pre_nodeadm[0].content, "echo 'RFVNTVktQ0EtUEVNLURBVEEK' | base64 -d > /etc/pki/ca-trust/source/anchors/org-ca.crt")
     error_message = "Pre-nodeadm script must decode the provided bundle into the AL2023 trust anchor directory."
@@ -67,6 +70,7 @@ run "bottlerocket_renders_toml_settings" {
     error_message = "Bottlerocket settings must declare [settings.pki.org-ca]."
   }
 
+  # Literal base64 (not ${var.extra_ca_bundle}) — same reasoning as the AL2023 assertion above.
   assert {
     condition     = strcontains(output.bootstrap_extra_args, "data = \"RFVNTVktQ0EtUEVNLURBVEEK\"")
     error_message = "Bottlerocket pki.data must contain the base64-encoded bundle verbatim."

--- a/modules/userdata/userdata.tftest.hcl
+++ b/modules/userdata/userdata.tftest.hcl
@@ -27,7 +27,7 @@ run "al2023_renders_cloudinit_pre_nodeadm" {
   }
 
   assert {
-    condition     = strcontains(output.cloudinit_pre_nodeadm[0].content, "echo '${var.extra_ca_bundle}' | base64 -d > /etc/pki/ca-trust/source/anchors/org-ca.crt")
+    condition     = strcontains(output.cloudinit_pre_nodeadm[0].content, "echo 'RFVNTVktQ0EtUEVNLURBVEEK' | base64 -d > /etc/pki/ca-trust/source/anchors/org-ca.crt")
     error_message = "Pre-nodeadm script must decode the provided bundle into the AL2023 trust anchor directory."
   }
 
@@ -68,7 +68,7 @@ run "bottlerocket_renders_toml_settings" {
   }
 
   assert {
-    condition     = strcontains(output.bootstrap_extra_args, "data = \"${var.extra_ca_bundle}\"")
+    condition     = strcontains(output.bootstrap_extra_args, "data = \"RFVNTVktQ0EtUEVNLURBVEEK\"")
     error_message = "Bottlerocket pki.data must contain the base64-encoded bundle verbatim."
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #32. Addresses the review suggestions plus the `docs` CI failure on `main`.

- **`modules/userdata/main.tf`** — replace the inline `<<-EOT` heredocs that built the AL2023 shellscript and the Bottlerocket TOML with `templatefile()` calls reading from two new files:
  - `modules/userdata/templates/install-extra-ca-bundle.sh.tftpl`
  - `modules/userdata/templates/bottlerocket-ca.toml.tftpl`

  The `.tf` keeps the null-pass-through and the AMI dispatch — only the payload bodies move. Editors now apply shellscript / TOML highlighting to the templates, and the scripts are independently lintable.

- **`modules/userdata/main.tf` (comment)** — drop the "same script works on AL2" claim. `cloudinit_pre_nodeadm` is the AL2023 nodeadm pre-hook, not the AL2 `bootstrap.sh` path, so the claim was misleading. AL2 coverage was never actually wired up.

- **`modules/userdata/userdata.tftest.hcl`** — hardcode the literal base64 (`RFVNTVktQ0EtUEVNLURBVEEK`) in the AL2023 and Bottlerocket assertions instead of re-interpolating `var.extra_ca_bundle`. If the production code ever transformed the bundle on its way into the rendered userdata, the previous assertions would transform the expected substring the same way and miss the bug.

- **`README.md`** — add the missing `node_userdata` row to the Modules table. The original PR added `extra_ca_bundle` to Inputs but didn't re-inject Modules, which is what the `docs` CI was flagging on `main`. README is now in sync with `terraform-docs markdown table` output (verified locally).

## Test plan

- [x] `cd modules/userdata && terraform test` — all 5 cases pass against the refactored module (AL2023 x86_64, AL2023 ARM, Bottlerocket, AL2023 no-op, Bottlerocket no-op).
- [x] `terraform fmt -recursive -check` — clean.
- [x] `terraform-docs markdown table --config .terraform-docs.yml --output-mode inject --output-file README.md .` produces no diff (docs check should pass).