### PR TITLE
Add support for Cluster Autoscaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,13 @@ module "cluster" {
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_aws_lb_controller_pod_identity"></a> [aws\_lb\_controller\_pod\_identity](#module\_aws\_lb\_controller\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.7.0 |
+| <a name="module_cluster_autoscaler_pod_identity"></a> [cluster\_autoscaler\_pod\_identity](#module\_cluster\_autoscaler\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.7.0 |
 | <a name="module_ebs_csi_pod_identity"></a> [ebs\_csi\_pod\_identity](#module\_ebs\_csi\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.7.0 |
 | <a name="module_efs"></a> [efs](#module\_efs) | terraform-aws-modules/efs/aws | 2.0.0 |
 | <a name="module_efs_csi_pod_identity"></a> [efs\_csi\_pod\_identity](#module\_efs\_csi\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.7.0 |
 | <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 21.11.0 |
 | <a name="module_iam"></a> [iam](#module\_iam) | ./modules/iam | n/a |
+| <a name="module_node_userdata"></a> [node\_userdata](#module\_node\_userdata) | ./modules/userdata | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 6.5.1 |
 | <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | ./modules/vpc-endpoints | n/a |
 
@@ -133,6 +135,7 @@ module "cluster" {
 | <a name="input_efs_throughput_mode"></a> [efs\_throughput\_mode](#input\_efs\_throughput\_mode) | The throughput mode of the EFS file system. Default is `bursting`. | `string` | `"bursting"` | no |
 | <a name="input_eks_kms_arn"></a> [eks\_kms\_arn](#input\_eks\_kms\_arn) | The ARN of the KMS key to use for encrypting EKS secrets. If not provided, EKS secrets will not be encrypted. | `string` | `null` | no |
 | <a name="input_enable_aws_load_balancer_controller_pod_identity"></a> [enable\_aws\_load\_balancer\_controller\_pod\_identity](#input\_enable\_aws\_load\_balancer\_controller\_pod\_identity) | Whether to provision the IAM role and EKS Pod Identity association for the AWS Load Balancer Controller. The role is bound to the `aws-load-balancer-controller` service account in `kube-system`. The controller itself is not installed by this module - consumers (e.g., nebari-infrastructure-core) are expected to install the Helm chart after cluster creation. Recommended for all new clusters. If you set this to false, you will need to    create your own IAM role and pod identity association | `bool` | `true` | no |
+| <a name="input_enable_cluster_autoscaler_pod_identity"></a> [enable\_cluster\_autoscaler\_pod\_identity](#input\_enable\_cluster\_autoscaler\_pod\_identity) | Whether to provision the IAM role and EKS Pod Identity association for the Kubernetes Cluster Autoscaler. The role is bound to the `cluster-autoscaler` service account in `kube-system`. The autoscaler itself is not installed by this module and consumers are expected to install the Helm chart after cluster creation. If you set this to false, you will need to create your own IAM role and pod identity association. | `bool` | `true` | no |
 | <a name="input_enable_cluster_creator_admin_permissions"></a> [enable\_cluster\_creator\_admin\_permissions](#input\_enable\_cluster\_creator\_admin\_permissions) | Whether to grant admin permissions to the IAM user or role that creates the EKS cluster. This allows the creator to manage the cluster after creation. | `bool` | `false` | no |
 | <a name="input_enable_irsa"></a> [enable\_irsa](#input\_enable\_irsa) | Whether to create the EKS OIDC provider for IAM Roles for Service Accounts. Set to false when the cluster relies exclusively on EKS Pod Identity, or when the VPC cannot resolve `oidc.eks.<region>.amazonaws.com` (a fully-private deployment with no public DNS resolution). When false, the upstream EKS module skips both the certificate-thumbprint fetch and the `aws_iam_openid_connect_provider` resource. | `bool` | `true` | no |
 | <a name="input_endpoint_private_access"></a> [endpoint\_private\_access](#input\_endpoint\_private\_access) | Indicates whether the Amazon EKS private API server endpoint is enabled. | `bool` | `true` | no |
@@ -158,6 +161,7 @@ module "cluster" {
 |------|-------------|
 | <a name="output_aws_load_balancer_controller_role_arn"></a> [aws\_load\_balancer\_controller\_role\_arn](#output\_aws\_load\_balancer\_controller\_role\_arn) | IAM role ARN for the AWS Load Balancer Controller pod identity association (null if enable\_aws\_load\_balancer\_controller\_pod\_identity is false) |
 | <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | The Amazon Resource Name (ARN) of the cluster |
+| <a name="output_cluster_autoscaler_role_arn"></a> [cluster\_autoscaler\_role\_arn](#output\_cluster\_autoscaler\_role\_arn) | IAM role ARN for the Cluster Autoscaler pod identity association (null if enable\_cluster\_autoscaler\_pod\_identity is false) |
 | <a name="output_cluster_certificate_authority_data"></a> [cluster\_certificate\_authority\_data](#output\_cluster\_certificate\_authority\_data) | Base64 encoded certificate data required to communicate with the cluster |
 | <a name="output_cluster_endpoint"></a> [cluster\_endpoint](#output\_cluster\_endpoint) | Endpoint for your Kubernetes API server |
 | <a name="output_cluster_iam_role_arn"></a> [cluster\_iam\_role\_arn](#output\_cluster\_iam\_role\_arn) | IAM role ARN of the EKS cluster |

--- a/main.tf
+++ b/main.tf
@@ -184,6 +184,31 @@ module "aws_lb_controller_pod_identity" {
   tags = var.tags
 }
 
+# The Cluster Autoscaler is not an EKS-managed addon, so the association is configured 
+# via the pod-identity module's `associations` argument. Consumers are expected to install
+# the Cluster Autoscaler helm chart separately.
+module "cluster_autoscaler_pod_identity" {
+  source  = "terraform-aws-modules/eks-pod-identity/aws"
+  version = "2.7.0"
+
+  count = var.enable_cluster_autoscaler_pod_identity ? 1 : 0
+
+  name = "${var.project_name}-cluster-autoscaler"
+
+  attach_cluster_autoscaler_policy = true
+  cluster_autoscaler_cluster_names = [var.project_name]
+
+  associations = {
+    this = {
+      cluster_name    = module.eks.cluster_name
+      namespace       = "kube-system"
+      service_account = "cluster-autoscaler"
+    }
+  }
+
+  tags = var.tags
+}
+
 module "vpc_endpoints" {
   source = "./modules/vpc-endpoints"
 

--- a/main.tf
+++ b/main.tf
@@ -193,7 +193,7 @@ module "cluster_autoscaler_pod_identity" {
 
   count = var.enable_cluster_autoscaler_pod_identity ? 1 : 0
 
-  name = "${var.project_name}-cluster-autoscaler"
+  name = "${var.project_name}-autoscaler"
 
   attach_cluster_autoscaler_policy = true
   cluster_autoscaler_cluster_names = [var.project_name]

--- a/outputs.tf
+++ b/outputs.tf
@@ -90,6 +90,11 @@ output "aws_load_balancer_controller_role_arn" {
   value       = one(module.aws_lb_controller_pod_identity[*].iam_role_arn)
 }
 
+output "cluster_autoscaler_role_arn" {
+  description = "IAM role ARN for the Cluster Autoscaler pod identity association (null if enable_cluster_autoscaler_pod_identity is false)"
+  value       = one(module.cluster_autoscaler_pod_identity[*].iam_role_arn)
+}
+
 ################################################################################
 # EFS
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -239,6 +239,12 @@ variable "enable_aws_load_balancer_controller_pod_identity" {
   default     = true
 }
 
+variable "enable_cluster_autoscaler_pod_identity" {
+  description = "Whether to provision the IAM role and EKS Pod Identity association for the Kubernetes Cluster Autoscaler. The role is bound to the `cluster-autoscaler` service account in `kube-system`. The autoscaler itself is not installed by this module and consumers are expected to install the Helm chart after cluster creation. If you set this to false, you will need to create your own IAM role and pod identity association."
+  type        = bool
+  default     = true
+}
+
 variable "enable_irsa" {
   description = "Whether to create the EKS OIDC provider for IAM Roles for Service Accounts. Set to false when the cluster relies exclusively on EKS Pod Identity, or when the VPC cannot resolve `oidc.eks.<region>.amazonaws.com` (a fully-private deployment with no public DNS resolution). When false, the upstream EKS module skips both the certificate-thumbprint fetch and the `aws_iam_openid_connect_provider` resource."
   type        = bool


### PR DESCRIPTION
# Closes

This is a companion PR for https://github.com/nebari-dev/nebari-infrastructure-core/pull/352

# Description

This PR adds the conditional creation of a pod identity for the cluster autoscaler, based on an input variable that defaults to true.

# How to test

Integration tests are passing in https://github.com/nebari-dev/terraform-aws-eks-cluster/actions/runs/26904381826/job/79365125961?pr=34

This PR is also tested indirectly by testing https://github.com/nebari-dev/nebari-infrastructure-core/pull/352



