### PR TITLE
Add per-node-group suspend_az_rebalance option

### DIFF
--- a/az_rebalance.tf
+++ b/az_rebalance.tf
@@ -1,0 +1,39 @@
+# Suspend the AZRebalance process on the ASGs backing EKS managed node groups
+# that opt in via `node_groups[*].suspend_az_rebalance = true`.
+#
+# EKS-managed node groups create ASGs with AZRebalance ENABLED by default.
+# AZRebalance terminates and relaunches instances to keep AZs balanced, which is
+# disruptive for any workload and an outright data-loss risk for stateful/storage
+# node groups (e.g. Longhorn): a storage node can be terminated purely to
+# rebalance AZs, taking its replica data with it. cluster-autoscaler manages real
+# capacity changes, so AZRebalance provides no benefit on managed node groups.
+#
+# Opt-in and per-node-group by design (default false) so this introduces no
+# behavior change for node groups that don't request it. EKS managed node groups
+# do not expose ASG suspended-processes natively, so this is applied
+# post-creation via the AWS CLI against each opted-in node group's backing ASG.
+# Requires the apply principal to have `autoscaling:SuspendProcesses` and the
+# `aws` CLI to be available in the apply environment.
+
+resource "terraform_data" "suspend_az_rebalance" {
+  for_each = { for name, cfg in var.node_groups : name => cfg if cfg.suspend_az_rebalance }
+
+  # Re-run if the node group's backing ASG(s) change (e.g. node group recreated).
+  triggers_replace = [
+    join(",", module.eks.eks_managed_node_groups[each.key].node_group_autoscaling_group_names),
+  ]
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/sh", "-c"]
+    command     = <<-EOT
+      set -eu
+      for asg in ${join(" ", module.eks.eks_managed_node_groups[each.key].node_group_autoscaling_group_names)}; do
+        echo "Suspending AZRebalance on ASG $asg (node group ${each.key})"
+        aws autoscaling suspend-processes \
+          --auto-scaling-group-name "$asg" \
+          --scaling-processes AZRebalance \
+          --region ${data.aws_region.current.region}
+      done
+    EOT
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -168,6 +168,7 @@ variable "node_groups" {
     - disk_size: Root disk size in GB (default: 20)
     - labels: Map of Kubernetes labels to apply to nodes (default: {})
     - taints: List of Kubernetes taints with keys: key, value, effect
+    - suspend_az_rebalance: Suspend the AZRebalance process on this node group's ASG (default: false). Recommended for stateful/storage node groups (e.g. Longhorn) to prevent disruptive AZ-rebalancing node terminations.
   EOT
   type = map(object({
     instance  = string
@@ -182,6 +183,7 @@ variable "node_groups" {
       value  = string
       effect = string # NO_SCHEDULE, NO_EXECUTE, or PREFER_NO_SCHEDULE
     })), [])
+    suspend_az_rebalance = optional(bool, false)
   }))
 
   validation {


### PR DESCRIPTION
## What

Adds an **opt-in, per-node-group** `suspend_az_rebalance` option (default `false`). When set `true` on a node group, the **AZRebalance** process is suspended on that node group's backing ASG.

```hcl
node_groups = {
  storage = {
    instance             = "m7g.large"
    # ...
    suspend_az_rebalance = true   # opt in, only where you want it
  }
}
```

## Why

EKS-managed node groups create ASGs with **AZRebalance enabled by default**. AZRebalance terminates and relaunches instances to keep AZs balanced — disruptive for any workload, and an outright **data-loss risk for stateful/storage node groups** (e.g. Longhorn): a storage node can be terminated purely to rebalance AZs, taking its replica data with it. `cluster-autoscaler` handles real capacity changes, so AZRebalance provides no benefit on managed node groups.

**Real-world trigger:** a dedicated Longhorn storage node group scaled to 3 nodes across 2 AZs (→ 2+1, imbalanced) with AZRebalance enabled is armed to terminate a storage node at any time to "balance," faulting volumes whose replicas live on it.

## Design

- **Opt-in, per-node-group, default `false`** → no behavior change for node groups (or existing module users) that don't set it. You enable it only where it matters (storage/stateful groups).
- Managed node groups don't expose ASG `suspended_processes` natively, so it's applied post-creation via the AWS CLI against the opted-in node group's ASG (`node_group_autoscaling_group_names`), keyed on the static `var.node_groups` map so `for_each` is known at plan time.

## Notes for reviewers

- ⚠️ **I couldn't run `terraform plan/apply` in my environment — please validate before merge.** Confirm the `node_group_autoscaling_group_names` attribute on `module.eks.eks_managed_node_groups` for the pinned EKS module version (21.11.0), and `terraform fmt`.
- Apply environment needs the **`aws` CLI** and the apply principal to have **`autoscaling:SuspendProcesses`**.
- Limitation: `terraform_data` re-runs only when the node group's ASG name changes; if AWS re-enables AZRebalance out-of-band, a re-apply (or trigger change) re-suspends it.

---

